### PR TITLE
CMake installation magic for Comme font

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,15 +38,6 @@ feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
 
 set(COMME_FONT_INSTALL_DIR  ${CMAKE_INSTALL_PREFIX}/${SHARE_INSTALL_PREFIX}/fonts/comme)
 set(VERSION_PATH "version-1.0")
-
-#set(fontFiles
-#    version-0.4/mono-400/OxygenMono-Regular.ttf
-#    version-0.4/Bold-700/Oxygen-Sans-Bold.ttf
-#    version-0.4/Regular-400/Oxygen-Sans.ttf
-#)
-
 FILE(GLOB fontFiles "${CMAKE_CURRENT_SOURCE_DIR}/${VERSION_PATH}/*.ttf")
 
 install(FILES ${fontFiles} DESTINATION ${COMME_FONT_INSTALL_DIR})
-#install(GLOB ${VERSION_PATH}/*ttf DESTINATION ${COMME_FONT_INSTALL_DIR})
-#INSTALL_FILES($VERSION_PATH} "\.ttf" DESTINATION ${COMME_FONT_INSTALL_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,52 @@
+
+cmake_minimum_required(VERSION 2.8.12)
+
+project(CommeFont)
+
+find_package(ECM 0.0.11 REQUIRED NO_MODULE)
+
+set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR})
+
+include(KDEInstallDirs)
+include(ECMPackageConfigHelpers)
+include(ECMSetupVersion)
+include(FeatureSummary)
+
+
+# create a Config.cmake and a ConfigVersion.cmake file and install them
+set(CMAKECONFIG_INSTALL_DIR "${CMAKECONFIG_INSTALL_PREFIX}/CommeFont")
+
+include(ECMPackageConfigHelpers)
+
+
+ecm_setup_version(1.0 VARIABLE_PREFIX COMMEFONT
+                  PACKAGE_VERSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/CommeFontConfigVersion.cmake"
+)
+
+ecm_configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/CommeFontConfig.cmake.in"
+                                  "${CMAKE_CURRENT_BINARY_DIR}/CommeFontConfig.cmake"
+                                  INSTALL_DESTINATION  ${CMAKECONFIG_INSTALL_DIR}
+)
+
+install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/CommeFontConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/CommeFontConfigVersion.cmake"
+        DESTINATION "${CMAKECONFIG_INSTALL_DIR}"
+        COMPONENT Devel)
+
+feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
+
+set(COMME_FONT_INSTALL_DIR  ${CMAKE_INSTALL_PREFIX}/${SHARE_INSTALL_PREFIX}/fonts/comme)
+set(VERSION_PATH "version-1.0")
+
+#set(fontFiles
+#    version-0.4/mono-400/OxygenMono-Regular.ttf
+#    version-0.4/Bold-700/Oxygen-Sans-Bold.ttf
+#    version-0.4/Regular-400/Oxygen-Sans.ttf
+#)
+
+FILE(GLOB fontFiles "${CMAKE_CURRENT_SOURCE_DIR}/${VERSION_PATH}/*.ttf")
+
+install(FILES ${fontFiles} DESTINATION ${COMME_FONT_INSTALL_DIR})
+#install(GLOB ${VERSION_PATH}/*ttf DESTINATION ${COMME_FONT_INSTALL_DIR})
+#INSTALL_FILES($VERSION_PATH} "\.ttf" DESTINATION ${COMME_FONT_INSTALL_DIR})

--- a/CommeFontConfig.cmake.in
+++ b/CommeFontConfig.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+
+set_package_properties(CommeFont PROPERTIES
+    DESCRIPTION "Comme Font, formerly known as Oxygen font"
+    URL "https://github.com/vernnobile/commeFont"
+    TYPE RUNTIME
+)


### PR DESCRIPTION
These files contain directions for the CMake build-system to install the
font. It makes it possible to install the fonts directly from the git
repo with build tools and continuous integration systems. It also makes 
it possible for tools to detect whether the font is installed, and in which 
version.

This is useful for using the Comme font in KDE projects, such as Plasma. :)
